### PR TITLE
Update Go versions and golangci-lint version in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: ["1.25", "1.26" ]
+        go-version: [ "1.26" ]
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +36,7 @@ jobs:
   Reviveci:
     strategy:
       matrix:
-        go-version: [ "1.25", "1.26" ]
+        go-version: [ "1.26" ]
     name: Run Revive Action
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +56,7 @@ jobs:
     # strategy set
     strategy:
       matrix:
-        go: [ "1.25", "1.26" ]
+        go: [ "1.26" ]
     steps:
       - name: Check source code
         uses: actions/checkout@v6.0.2
@@ -71,7 +71,7 @@ jobs:
     # strategy set
     strategy:
       matrix:
-        go: [ "1.25", "1.26" ]
+        go: [ "1.26" ]
     
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9.2.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v2.12.2
+          version: v2.12
 
   Reviveci:
     strategy:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go-version: ["1.24" ]
+        go-version: ["1.25", "1.26" ]
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
@@ -31,12 +31,12 @@ jobs:
         uses: golangci/golangci-lint-action@v9.2.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v2.1.0
+          version: v2.12.2
 
   Reviveci:
     strategy:
       matrix:
-        go-version: [ "1.24" ]
+        go-version: [ "1.25", "1.26" ]
     name: Run Revive Action
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +56,7 @@ jobs:
     # strategy set
     strategy:
       matrix:
-        go: [ "1.24" ]
+        go: [ "1.25", "1.26" ]
     steps:
       - name: Check source code
         uses: actions/checkout@v6.0.2
@@ -71,7 +71,7 @@ jobs:
     # strategy set
     strategy:
       matrix:
-        go: [ "1.24" ]
+        go: [ "1.25", "1.26" ]
     
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 run:
   concurrency: 4
-  go: "1.21"
+  go: "1.25"
   build-tags:
     - mytag
   modules-download-mode: readonly


### PR DESCRIPTION
Updated Go version in workflows to support 1.25 and 1.26. Upgraded golangci-lint version to v2.12.2.